### PR TITLE
Forward all labels to the snapshotter

### DIFF
--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -18,7 +18,7 @@ import (
 )
 
 // PrepareSnapshot prepares a snapshot from a parent image for a container
-func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error {
+func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error, labels map[string]string) error {
 	var parentSnapshot string
 	if parentImage != "" {
 		img, err := i.resolveImage(ctx, parentImage)
@@ -72,7 +72,10 @@ func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentIma
 		return i.remapSnapshot(ctx, snapshotter, id, id+"-init")
 	}
 
-	_, err = snapshotter.Prepare(ctx, id, id+"-init")
+	sops := []snapshots.Opt {
+		snapshots.WithLabels(labels),
+	}
+	_, err = snapshotter.Prepare(ctx, id, id+"-init", sops...)
 	return err
 }
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -197,7 +197,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	ctr.ImageManifest = imgManifest
 
 	if daemon.UsesSnapshotter() {
-		if err := daemon.imageService.PrepareSnapshot(ctx, ctr.ID, opts.params.Config.Image, opts.params.Platform, setupInitLayer(daemon.idMapping)); err != nil {
+		if err := daemon.imageService.PrepareSnapshot(ctx, ctr.ID, opts.params.Config.Image, opts.params.Platform, setupInitLayer(daemon.idMapping), opts.params.Config.Labels); err != nil {
 			return nil, err
 		}
 	} else {

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -47,7 +47,7 @@ type ImageService interface {
 
 	// Containerd related methods
 
-	PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error
+	PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error, labels map[string]string) error
 	GetImageManifest(ctx context.Context, refOrID string, options backend.GetImageOpts) (*ocispec.Descriptor, error)
 
 	// Layers

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -45,7 +45,7 @@ type manifest struct {
 	Config ocispec.Descriptor `json:"config"`
 }
 
-func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error {
+func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error, labels map[string]string) error {
 	// Only makes sense when containerd image store is used
 	panic("not implemented")
 }


### PR DESCRIPTION
Ideally we would have separate snapshotter labels such as with the `--snapshotter-label` option to `ctr container create`. The containerd daemon will automatically filter out labels that don't match a snapshotter and I really don't want to add a new field to the server API right now. /shurg